### PR TITLE
Fixed distance calculation, Re-written unoptimal code

### DIFF
--- a/lib/mailcheck.rb
+++ b/lib/mailcheck.rb
@@ -104,9 +104,9 @@ class Mailcheck
     return false if domain_parts.length == 0
 
     {
-      :top_level_domain => domain_parts.join('.'),
+      :top_level_domain => domain_parts[1..-1].join('.'),
       :domain => domain,
-      :address => parts.join('@')
+      :address => parts.first
     }
   end
 end


### PR DESCRIPTION
Fixes bug in calculation distance between strings, distance was rounded down to integer number, e.g `3.9` -> `3`

``` ruby
# was
mailcheck.suggest "user@juno.com" #-> 'user@msn.com'

# now - same as mailcheck.js
mailcheck.suggest "user@juno.com" #-> false

```
- Fixed distance calculation. 
- Re-written some unoptimal code
- Make code closer to style guide
